### PR TITLE
Optimize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ MAINTAINER Sam Powers <sampowers@gmail.com>
 ENV BUILDDEPS="curl build-base automake autoconf libtool avahi-dev libgcrypt-dev linux-pam-dev cracklib-dev db-dev libevent-dev krb5-dev tdb-dev file"
 ENV RUNTIMEDEPS="avahi libldap libgcrypt python avahi dbus dbus-glib py-dbus linux-pam cracklib db libevent krb5 tdb"
 
-RUN apk --no-cache add $BUILDDEPS $RUNTIMEDEPS
-RUN mkdir -p /build/netatalk \
-&& curl -Ls https://github.com/Netatalk/Netatalk/archive/netatalk-3-1-10.tar.gz | tar zx -C /build/netatalk --strip-components=1
-RUN cd /build/netatalk \
+RUN apk --no-cache add $BUILDDEPS $RUNTIMEDEPS \
+&& mkdir -p /build/netatalk \
+&& curl -Ls https://github.com/Netatalk/Netatalk/archive/netatalk-3-1-10.tar.gz | tar zx -C /build/netatalk --strip-components=1 \
+&& cd /build/netatalk \
 && ./bootstrap \
 && ./configure \
 --prefix=/usr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /build/netatalk \
 --with-pam-confdir=/etc/pam.d \
 --with-dbus-sysconf-dir=/etc/dbus-1/system.d \
 --with-tracker-pkgconfig-version=0.16 \
-&& make \
+&& make -j $(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
 && make install \
 && cd / && rm -rf /build \
 && mkdir /media/share \


### PR DESCRIPTION
Thank you for pulling previous request, and there is another one here.
These two commits are for optimization of building process.

The first one sets -j option for make command depending on the number of CPUs it can use concurrently, and the second one shrinks the resulting image.

With the latter, the size of image drops to about 1/5 as below.

~~~
REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
docker-netatalk-optimized      latest              1d444e562751        7 seconds ago       64.7 MB
docker-netatalk-original       latest              1568a7a0f8ba        6 minutes ago       298 MB
~~~

The same thing is going on the mainline and details are described there:
https://github.com/cptactionhank/docker-netatalk/pull/13

Thanks